### PR TITLE
Replace unset variable and save asset_index to a file

### DIFF
--- a/5-asset_create.py
+++ b/5-asset_create.py
@@ -65,8 +65,8 @@ def main() :
         json.dumps(confirmed_txn, indent=4)))
 
     # write the asset index to an environment file
-    f = open('asset.env', 'w+')
-    f.write(f'ASSET_INDEX={confirmed_txn["asset-index"]}')
+    f = open('asset.index', 'w+')
+    f.write(f'{confirmed_txn["asset-index"]}')
     f.close()
 
 main()

--- a/5-asset_create.py
+++ b/5-asset_create.py
@@ -64,4 +64,9 @@ def main() :
     print("Transaction information: {}".format(
         json.dumps(confirmed_txn, indent=4)))
 
+    # write the asset index to an environment file
+    f = open('asset.env', 'w+')
+    f.write(f'ASSET_INDEX={confirmed_txn["asset-index"]}')
+    f.close()
+
 main()

--- a/5-asset_create.py
+++ b/5-asset_create.py
@@ -34,7 +34,7 @@ def main() :
     unsigned_txn = transaction.AssetConfigTxn(sender=addr1,
             sp=params,
             total=10000,  # Fungible tokens have total issuance greater than 1
-            decimals=2    # Fungible tokens typically have decimals greater than 0
+            decimals=2,    # Fungible tokens typically have decimals greater than 0
             default_frozen=False,
             unit_name="FUNTOK",
             asset_name="Fun Token",

--- a/6-asset_optin.py
+++ b/6-asset_optin.py
@@ -16,9 +16,7 @@ algod_token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 def get_asset_index(default_index = 2):
     # try to read the asset index from our environment file
     try:
-        for line in open('asset.env', 'r'):
-            if "ASSET_INDEX=" in line:
-                index = int(line.removeprefix("ASSET_INDEX="))
+        index = int(open('asset.index', 'r').readline())
     # otherwise return the default index
     except:
         index = default_index
@@ -43,7 +41,7 @@ def main() :
     # build unsigned transaction
     params = algod_client.suggested_params()
     sender = addr2
-    index = get_asset_index(2) # ensure this matches the asset-index returned by asset_create.py
+    index = get_asset_index(default_index = 2) # ensure this matches the asset-index returned by asset_create.py
     unsigned_txn = transaction.AssetOptInTxn(sender, params, index)
     
     # sign transaction

--- a/6-asset_optin.py
+++ b/6-asset_optin.py
@@ -12,7 +12,18 @@ kmd_token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 # define sandbox values for algod client
 algod_address = "http://localhost:4001"
 algod_token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    
+
+def get_asset_index(default_index = 2):
+    # try to read the asset index from our environment file
+    try:
+        for line in open('asset.env', 'r'):
+            if "ASSET_INDEX=" in line:
+                index = int(line.removeprefix("ASSET_INDEX="))
+    # otherwise return the default index
+    except:
+        index = default_index
+    return index
+
 def main() :
     # create KMDClient
     kmd_client = kmd.KMDClient(kmd_token, kmd_address)
@@ -32,7 +43,7 @@ def main() :
     # build unsigned transaction
     params = algod_client.suggested_params()
     sender = addr2
-    index = 2 # ensure this matches the asset-index returned by asset_create.py
+    index = get_asset_index(2) # ensure this matches the asset-index returned by asset_create.py
     unsigned_txn = transaction.AssetOptInTxn(sender, params, index)
     
     # sign transaction

--- a/7-atomic_transaction.py
+++ b/7-atomic_transaction.py
@@ -14,6 +14,17 @@ kmd_token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 algod_address = "http://localhost:4001"
 algod_token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     
+def get_asset_index(default_index = 2):
+    # try to read the asset index from our environment file
+    try:
+        for line in open('asset.env', 'r'):
+            if "ASSET_INDEX=" in line:
+                index = int(line.removeprefix("ASSET_INDEX="))
+    # otherwise return the default index
+    except:
+        index = default_index
+    return index
+
 def main() :
     # create KMDClient
     kmd_client = kmd.KMDClient(kmd_token, kmd_address)
@@ -41,7 +52,7 @@ def main() :
     sender = addr1
     receiver = addr2
     amount = 100 # remember this ASA has 2 decimal places, so this is 1.00 FUNTOK 
-    index = 2 # ensure this matches the asset-index returned by asset_create.py
+    index = get_asset_index(2) # ensure this matches the asset-index returned by asset_create.py
     txn_2 = transaction.AssetTransferTxn(sender, params, receiver, amount, index)
 
     # group transactions

--- a/7-atomic_transaction.py
+++ b/7-atomic_transaction.py
@@ -17,9 +17,7 @@ algod_token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 def get_asset_index(default_index = 2):
     # try to read the asset index from our environment file
     try:
-        for line in open('asset.env', 'r'):
-            if "ASSET_INDEX=" in line:
-                index = int(line.removeprefix("ASSET_INDEX="))
+        index = int(open('asset.index', 'r').readline())
     # otherwise return the default index
     except:
         index = default_index
@@ -52,7 +50,7 @@ def main() :
     sender = addr1
     receiver = addr2
     amount = 100 # remember this ASA has 2 decimal places, so this is 1.00 FUNTOK 
-    index = get_asset_index(2) # ensure this matches the asset-index returned by asset_create.py
+    index = get_asset_index(default_index = 2) # ensure this matches the asset-index returned by asset_create.py
     txn_2 = transaction.AssetTransferTxn(sender, params, receiver, amount, index)
 
     # group transactions

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Sample output:
 
 Set environment variables for default account addresses for CLI usage:
 ```
-ADDR1=$($SANDBOX goal account list | awk 'FNR==1{ print $2 }')
-ADDR2=$($SANDBOX goal account list | awk 'FNR==2{ print $2 }')
-ADDR3=$($SANDBOX goal account list | awk 'FNR==3{ print $2 }')
+ADDR1=$(./sandbox goal account list | awk 'FNR==1{ print $2 }')
+ADDR2=$(./sandbox goal account list | awk 'FNR==2{ print $2 }')
+ADDR3=$(./sandbox goal account list | awk 'FNR==3{ print $2 }')
 ```
 
 Display an account _Balance Record_ using:


### PR DESCRIPTION
We either need to set 'SANDBOX=./sandbox', or use './sandbox' by itself here. The rest of the document uses './sandbox' by itself, so I've done that here for consistency.