### PR TITLE
bug fix on smart contract

### DIFF
--- a/session_3/auction.py
+++ b/session_3/auction.py
@@ -113,10 +113,7 @@ class Auction(Application):
                     TxnField.fee: Int(0),
                     TxnField.xfer_asset: self.asa,
                     TxnField.asset_receiver: self.highest_bidder,
-                    TxnField.asset_close_to: Seq(
-                        (asa_creator := asset.params().creator_address()),
-                        asa_creator.value(),
-                    ),
+                    TxnField.asset_close_to: self.highest_bidder,
                 }
             ),
         )

--- a/session_4/auction.py
+++ b/session_4/auction.py
@@ -115,10 +115,7 @@ class Auction(Application):
                     TxnField.fee: Int(0),
                     TxnField.xfer_asset: self.asa,
                     TxnField.asset_receiver: self.highest_bidder,
-                    TxnField.asset_close_to: Seq(
-                        (asa_creator := asset.params().creator_address()),
-                        asa_creator.value(),
-                    ),
+                    TxnField.asset_close_to: self.highest_bidder,
                 }
             ),
         )


### PR DESCRIPTION
fixed bug where smart contract sends the winning NFT to the asset_close_to field of the asset transfer transaction to the address of the asset creator, which means that the asset will be sent to that address instead of the highest bidder.